### PR TITLE
feat(alert): don't play sound on alerts from lessons

### DIFF
--- a/features/customAlertSound.js
+++ b/features/customAlertSound.js
@@ -5,6 +5,11 @@ export async function customAlertSound(alert) {
 		console.log("New alert received: " + alert.missionName);
 	}
 
+	// Don't play the sound if the alert is an academy lesson
+	if (alert.origin === 3) {
+		return;
+	}
+
 	try {
 		await playAudio(process.env.CUSTOM_ALERT_SOUND);
 		console.log("Playback finished for alert.");


### PR DESCRIPTION
Just had the alert sound play because of today's lesson zero.
This should fix it

https://medrunner.dev/reference/types/enumerations/Origin.html